### PR TITLE
Set the sbt version to 0.13.17

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.17


### PR DESCRIPTION
This fixes #10. The problem is that the project didn't specify the sbt version to use, and resolving of build-time dependencies relies on sbt version used.

According to TravisCI log, they use 0.13.16 so I'm using 0.13.17.