### PR TITLE
Remove URL escaping for BridgeApp classpath in WindowsPluginFrontend

### DIFF
--- a/src/main/scala/protocbridge/frontend/WindowsPluginFrontend.scala
+++ b/src/main/scala/protocbridge/frontend/WindowsPluginFrontend.scala
@@ -1,7 +1,7 @@
 package protocbridge.frontend
 
 import java.net.ServerSocket
-import java.nio.file.{Files, Path}
+import java.nio.file.{Files, Path, Paths}
 
 import protocbridge.ProtocCodeGenerator
 
@@ -36,9 +36,10 @@ object WindowsPluginFrontend extends PluginFrontend {
   }
 
   private def createWindowsScript(port: Int): InternalState = {
+    val classPath = Paths.get(getClass.getProtectionDomain.getCodeSource.getLocation.toURI)
     val batchFile = PluginFrontend.createTempFile(".bat",
       s"""@echo off
-          |"${sys.props("java.home")}\\bin\\java.exe" -cp "${getClass.getProtectionDomain.getCodeSource.getLocation.getPath}" ${classOf[BridgeApp].getName} $port
+          |"${sys.props("java.home")}\\bin\\java.exe" -cp "$classPath" ${classOf[BridgeApp].getName} $port
         """.stripMargin)
     InternalState(batchFile)
   }

--- a/src/main/scala/protocbridge/frontend/WindowsPluginFrontend.scala
+++ b/src/main/scala/protocbridge/frontend/WindowsPluginFrontend.scala
@@ -37,9 +37,10 @@ object WindowsPluginFrontend extends PluginFrontend {
 
   private def createWindowsScript(port: Int): InternalState = {
     val classPath = Paths.get(getClass.getProtectionDomain.getCodeSource.getLocation.toURI)
+    val classPathBatchString = classPath.toString.replaceAllLiterally("%", "%%")
     val batchFile = PluginFrontend.createTempFile(".bat",
       s"""@echo off
-          |"${sys.props("java.home")}\\bin\\java.exe" -cp "$classPath" ${classOf[BridgeApp].getName} $port
+          |"${sys.props("java.home")}\\bin\\java.exe" -cp "$classPathBatchString" ${classOf[BridgeApp].getName} $port
         """.stripMargin)
     InternalState(batchFile)
   }


### PR DESCRIPTION
When using Coursier to fetch sbt dependencies, artifact paths contain escaped repository URLs like `c:\Users\keritaf\AppData\Local\Coursier\cache\v1\http\localhost%3A13030\artifactory\public\com\thesamet\scalapb\protoc-bridge_2.12\0.7.2\protoc-bridge_2.12-0.7.2.jar`

Classpath written into BAT file `WindowsPluginFrontend` is generated from `URL`, which is escaped in `.getPath` output. This leads to incorrect classpath being set: `-cp "/C:/Users/keritaf/AppData/Local/Coursier/cache/v1/http/localhost%253A13030/artifactory/public/com/thesamet/scalapb/protoc-bridge_2.12/0.7.2/protoc-bridge_2.12-0.7.2.jar"`. As a result, sbt build fails:
```
Error: Could not find or load main class protocbridge.frontend.BridgeApp
--scala_out: protoc-gen-scala: Plugin failed with status code 1.
```

The proposed fix is to convert the URL to Path and use it as the classpath. The resulting classpath in BAT: `-cp "C:\Users\keritaf\AppData\Local\Coursier\cache\v1\http\localhost%3A13030\artifactory\snapshots\com\thesamet\scalapb\protoc-bridge_2.12\0.7.3-SNAPSHOT\protoc-bridge_2.12-0.7.3-SNAPSHOT.jar"`