### PR TITLE
fix deprecation warning

### DIFF
--- a/src/main/scala/protocbridge/ProtocBridge.scala
+++ b/src/main/scala/protocbridge/ProtocBridge.scala
@@ -45,7 +45,7 @@ object ProtocBridge {
   def run[A](protoc: Seq[String] => A,
              targets: Seq[Target],
              params: Seq[String],
-             pluginFrontend: PluginFrontend = PluginFrontend.newInstance()): A = {
+             pluginFrontend: PluginFrontend = PluginFrontend.newInstance): A = {
 
     val namedGenerators: Seq[(String, ProtocCodeGenerator)] =
       targets.collect {
@@ -64,7 +64,7 @@ object ProtocBridge {
   def runWithGenerators[A](protoc: Seq[String] => A,
                            namedGenerators: Seq[(String, ProtocCodeGenerator)],
                            params: Seq[String],
-                           pluginFrontend: PluginFrontend = PluginFrontend.newInstance()): A = {
+                           pluginFrontend: PluginFrontend = PluginFrontend.newInstance): A = {
 
     val generatorScriptState: Seq[(String, (Path, pluginFrontend.InternalState))] =
       namedGenerators.map {


### PR DESCRIPTION
```
[warn] protoc-bridge/src/main/scala/protocbridge/ProtocBridge.scala:48:62: method newInstance in object PluginFrontend is deprecated (since 0.7.2): Use 'newInstance' instead
[warn]              pluginFrontend: PluginFrontend = PluginFrontend.newInstance()): A = {
[warn]                                                              ^
[warn] protoc-bridge/src/main/scala/protocbridge/ProtocBridge.scala:67:76: method newInstance in object PluginFrontend is deprecated (since 0.7.2): Use 'newInstance' instead
[warn]                            pluginFrontend: PluginFrontend = PluginFrontend.newInstance()): A = {
[warn]                                                                            ^
```