### PR TITLE
assign uniquely-suffixed names to JvmGenerators to allow reuse

### DIFF
--- a/src/main/scala/protocbridge/ProtocCodeGenerator.scala
+++ b/src/main/scala/protocbridge/ProtocCodeGenerator.scala
@@ -10,7 +10,6 @@ trait ProtocCodeGenerator {
 object ProtocCodeGenerator {
   import scala.language.implicitConversions
 
-  implicit def toGenerator(p: ProtocCodeGenerator): Generator = {
-    JvmGenerator("jvm_" + scala.util.Random.alphanumeric.take(8).mkString, p)
-  }
+  implicit def toGenerator(p: ProtocCodeGenerator): Generator =
+    JvmGenerator("jvm", p)
 }

--- a/src/test/scala/protocbridge/ProtocBridgeSpec.scala
+++ b/src/test/scala/protocbridge/ProtocBridgeSpec.scala
@@ -121,11 +121,21 @@ class ProtocBridgeSpec extends FlatSpec with MustMatchers {
     }
   }
 
-  it should "allow using fooBarGen" in {
-    run(Seq(Target(foobarGen("x", "y"), TmpPath))) must be(
+  it should "allow using fooBarGen multiple times" in {
+    run(
       Seq(
-        "--plugin=protoc-gen-fff=null",
-        s"--fff_out=x,y:$TmpPath"
+        Target(foobarGen("x", "y"), TmpPath),
+        FoobarGen -> TmpPath1,
+        Target(foobarGen("foo", "bar"), TmpPath2)
+      )
+    ) must be(
+      Seq(
+        "--plugin=protoc-gen-fff_0=null",
+        "--plugin=protoc-gen-jvm_1=null",
+        "--plugin=protoc-gen-fff_2=null",
+        s"--fff_0_out=x,y:$TmpPath",
+        s"--jvm_1_out=:$TmpPath1",
+        s"--fff_2_out=foo,bar:$TmpPath2"
       )
     )
   }

--- a/src/test/scala/protocbridge/TargetSpec.scala
+++ b/src/test/scala/protocbridge/TargetSpec.scala
@@ -79,23 +79,6 @@ class TargetSpec extends FlatSpec with MustMatchers {
     }
   }
 
-  it should "using ProtocCodeGenerator and assigning random name" in {
-    Target(FoobarGen, TmpPath) must matchPattern {
-      case Target(JvmGenerator(name, FoobarGen), TmpPath, Nil)
-          if name.startsWith("jvm_") =>
-    }
-
-    (FoobarGen -> TmpPath: Target) must matchPattern {
-      case Target(JvmGenerator(name, FoobarGen), TmpPath, Nil)
-          if name.startsWith("jvm_") =>
-    }
-
-    ((FoobarGen, Seq("x", "y")) -> TmpPath: Target) must matchPattern {
-      case Target(JvmGenerator(name, FoobarGen), TmpPath, Seq("x", "y"))
-          if name.startsWith("jvm_") =>
-    }
-  }
-
   it should "allow using the options syntax" in {
     Target(foobarGen("xyz", "wf"), TmpPath) must matchPattern {
       case Target(JvmGenerator("fff", FoobarGen), TmpPath, Seq("xyz", "wf")) =>


### PR DESCRIPTION
It is valid for `protoc` to have the same plugin be used several times (with different `out` values), but this did not work if the plugin was backed by the same `JvmGenerator` (`protoc` hanged forever), as the frontend is not able to serve 2 invocations within the same session.
    
This typically happened when [ScalaPB](https://github.com/scalapb/ScalaPB/blob/21727bf/compiler-plugin/src/main/scala/scalapb/package.scala#L26) was passed twice.

This is a follow-up of https://github.com/thesamet/sbt-protoc/issues/108 where I first observed this behavior.

