### PR TITLE
add file descriptor set built-in generator

### DIFF
--- a/src/main/scala/protocbridge/Generator.scala
+++ b/src/main/scala/protocbridge/Generator.scala
@@ -28,7 +28,7 @@ final case class PluginGenerator(
 ) extends Generator
 
 /** Represents a generator built into protoc, to be used with a file target. */
-final case object DescriptorSetGenerator extends Generator {
+final case class DescriptorSetGenerator() extends Generator {
   override val name = "descriptor_set"
   override val suggestedDependencies = Nil
 }
@@ -69,5 +69,5 @@ object gens {
   val go = BuiltinGenerator("go")
   val swagger = BuiltinGenerator("swagger")
   val gateway = BuiltinGenerator("grpc-gateway")
-  val descriptorset = DescriptorSetGenerator
+  val descriptorset = DescriptorSetGenerator()
 }

--- a/src/main/scala/protocbridge/Generator.scala
+++ b/src/main/scala/protocbridge/Generator.scala
@@ -69,5 +69,5 @@ object gens {
   val go = BuiltinGenerator("go")
   val swagger = BuiltinGenerator("swagger")
   val gateway = BuiltinGenerator("grpc-gateway")
-  val descriptorset = DescriptorSetGenerator()
+  val descriptorSet = DescriptorSetGenerator()
 }

--- a/src/main/scala/protocbridge/Generator.scala
+++ b/src/main/scala/protocbridge/Generator.scala
@@ -15,7 +15,7 @@ sealed trait Generator {
   def suggestedDependencies: Seq[Artifact]
 }
 
-/** Represents a generator built into protoc.  */
+/** Represents a generator built into protoc, to be used with a directory target. */
 final case class BuiltinGenerator(
     name: String,
     suggestedDependencies: Seq[Artifact] = Nil
@@ -26,6 +26,12 @@ final case class PluginGenerator(
     suggestedDependencies: Seq[Artifact],
     path: Option[String]
 ) extends Generator
+
+/** Represents a generator built into protoc, to be used with a file target. */
+final case object DescriptorSetGenerator extends Generator {
+  override val name = "descriptor_set"
+  override val suggestedDependencies = Nil
+}
 
 /** Represents a generator implemented by ProtocCodeGenerator. */
 final case class JvmGenerator(name: String, gen: ProtocCodeGenerator)
@@ -63,4 +69,5 @@ object gens {
   val go = BuiltinGenerator("go")
   val swagger = BuiltinGenerator("swagger")
   val gateway = BuiltinGenerator("grpc-gateway")
+  val descriptorset = DescriptorSetGenerator
 }

--- a/src/main/scala/protocbridge/ProtocBridge.scala
+++ b/src/main/scala/protocbridge/ProtocBridge.scala
@@ -75,7 +75,9 @@ object ProtocBridge {
       }
 
     val cmdLine: Seq[String] = pluginArgs(targets) ++ targetsSuffixed.map { p =>
-      s"--${p.generator.name}_out=${p.options.mkString(",")}:${p.outputPath.getAbsolutePath}"
+      val maybeOptions =
+        if (p.options.nonEmpty) p.options.mkString("", ",", ":") else ""
+      s"--${p.generator.name}_out=$maybeOptions${p.outputPath.getAbsolutePath}"
     } ++ params
 
     runWithGenerators(protoc, namedGenerators, cmdLine, pluginFrontend)

--- a/src/test/scala/protocbridge/ProtocBridgeSpec.scala
+++ b/src/test/scala/protocbridge/ProtocBridgeSpec.scala
@@ -41,7 +41,7 @@ class ProtocBridgeSpec extends AnyFlatSpec with Matchers {
 
   "run" should "allow string args for string generators" in {
     run(Seq(Target(Target.builtin("java"), TmpPath))) must be(
-      Seq(s"--java_out=:$TmpPath")
+      Seq(s"--java_out=$TmpPath")
     )
     run(Seq(Target(Target.builtin("java", Seq("x", "y", "z")), TmpPath))) must be(
       Seq(s"--java_out=x,y,z:$TmpPath")
@@ -49,7 +49,7 @@ class ProtocBridgeSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "pass builtin targets correctly" in {
-    run(Seq(Target(gens.java, TmpPath))) must be(Seq(s"--java_out=:$TmpPath"))
+    run(Seq(Target(gens.java, TmpPath))) must be(Seq(s"--java_out=$TmpPath"))
     run(Seq(Target(gens.java, TmpPath, Seq("x", "y")))) must be(
       Seq(s"--java_out=x,y:$TmpPath")
     )
@@ -57,14 +57,14 @@ class ProtocBridgeSpec extends AnyFlatSpec with Matchers {
 
   it should "pass external plugins correctly" in {
     run(Seq(Target(gens.plugin("foo"), TmpPath))) must be(
-      Seq(s"--foo_out=:$TmpPath")
+      Seq(s"--foo_out=$TmpPath")
     )
     run(
       Seq(
         Target(gens.plugin("foo"), TmpPath),
         Target(gens.plugin("bar"), TmpPath2)
       )
-    ) must be(Seq(s"--foo_out=:$TmpPath", s"--bar_out=:$TmpPath2"))
+    ) must be(Seq(s"--foo_out=$TmpPath", s"--bar_out=$TmpPath2"))
 
     run(
       Seq(
@@ -74,8 +74,8 @@ class ProtocBridgeSpec extends AnyFlatSpec with Matchers {
     ) must be(
       Seq(
         "--plugin=protoc-gen-foo=/path/to/plugin",
-        s"--foo_out=:$TmpPath",
-        s"--bar_out=:$TmpPath2"
+        s"--foo_out=$TmpPath",
+        s"--bar_out=$TmpPath2"
       )
     )
 
@@ -89,10 +89,10 @@ class ProtocBridgeSpec extends AnyFlatSpec with Matchers {
     ) must be(
       Seq(
         "--plugin=protoc-gen-foo=/path/to/plugin",
-        s"--foo_out=:$TmpPath",
-        s"--foo_out=:$TmpPath1",
-        s"--foo_out=:$TmpPath2",
-        s"--bar_out=:$TmpPath"
+        s"--foo_out=$TmpPath",
+        s"--foo_out=$TmpPath1",
+        s"--foo_out=$TmpPath2",
+        s"--bar_out=$TmpPath"
       )
     )
   }
@@ -109,7 +109,7 @@ class ProtocBridgeSpec extends AnyFlatSpec with Matchers {
   }
 
   val DefineFlag = "--plugin=protoc-gen-jvm_(.*?)=null".r
-  val UseFlag = s"--jvm_(.*?)_out=:${Pattern.quote(TmpPath.toString)}".r
+  val UseFlag = s"--jvm_(.*?)_out=${Pattern.quote(TmpPath.toString)}".r
   val UseFlagParams =
     s"--jvm_(.*?)_out=x,y:${Pattern.quote(TmpPath.toString)}".r
 
@@ -136,7 +136,7 @@ class ProtocBridgeSpec extends AnyFlatSpec with Matchers {
         "--plugin=protoc-gen-jvm_1=null",
         "--plugin=protoc-gen-fff_2=null",
         s"--fff_0_out=x,y:$TmpPath",
-        s"--jvm_1_out=:$TmpPath1",
+        s"--jvm_1_out=$TmpPath1",
         s"--fff_2_out=foo,bar:$TmpPath2"
       )
     )


### PR DESCRIPTION
This maps the [protoc `--descriptor_set_out` flag](https://github.com/protocolbuffers/protobuf/blob/f0cb9cdb957e27c191d67a3154b72f383a4ad60f/src/google/protobuf/compiler/command_line_interface.cc#L1826-L1830) to a generator, which seems to work from a CLI/model perspective. However, when used through `sbt-protoc` (and potentially other projects that make use of this), the fact that this new generator's target is a file rather than a directory breaks some assumptions: [sbt-protoc `mkdir` the target](https://github.com/thesamet/sbt-protoc/blob/294dd55/src/main/scala/sbtprotoc/ProtocPlugin.scala#L197)...

For some context: I initially tried to use the [`protocOptions` setting key](https://github.com/thesamet/sbt-protoc/blob/294dd55/src/main/scala/sbtprotoc/ProtocPlugin.scala#L171) to get descriptor set output, but the fact that `protoc` [is not run when no target exists](https://github.com/thesamet/sbt-protoc/blob/294dd55/src/main/scala/sbtprotoc/ProtocPlugin.scala#L200) and that the sbt plugin does not have knowledge about the output (which impacts caching) made me want to try promoting this to a first citizen generator, until I ran into this concern.

Any thought? Similar discussion in another project: https://github.com/uber/prototool/issues/211#issuecomment-416772701