### PR TITLE
fix deadlock experienced via sbt-protoc

### DIFF
--- a/src/main/scala/protocbridge/frontend/PosixPluginFrontend.scala
+++ b/src/main/scala/protocbridge/frontend/PosixPluginFrontend.scala
@@ -5,6 +5,7 @@ import java.nio.file.{Files, Path}
 import protocbridge.ProtocCodeGenerator
 import java.nio.file.attribute.PosixFilePermission
 
+import scala.concurrent.blocking
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.JavaConverters._
@@ -29,13 +30,15 @@ object PosixPluginFrontend extends PluginFrontend {
     val sh = createShellScript(inputPipe, outputPipe)
 
     Future {
-      val fsin = Files.newInputStream(inputPipe)
-      val response = PluginFrontend.runWithInputStream(plugin, fsin)
-      fsin.close()
+      blocking {
+        val fsin = Files.newInputStream(inputPipe)
+        val response = PluginFrontend.runWithInputStream(plugin, fsin)
+        fsin.close()
 
-      val fsout = Files.newOutputStream(outputPipe)
-      fsout.write(response)
-      fsout.close()
+        val fsout = Files.newOutputStream(outputPipe)
+        fsout.write(response)
+        fsout.close()
+      }
     }
     (sh, InternalState(inputPipe, outputPipe, tempDirPath, sh))
   }

--- a/src/main/scala/protocbridge/frontend/WindowsPluginFrontend.scala
+++ b/src/main/scala/protocbridge/frontend/WindowsPluginFrontend.scala
@@ -5,6 +5,8 @@ import java.nio.file.{Files, Path, Paths}
 
 import protocbridge.ProtocCodeGenerator
 
+import scala.concurrent.blocking
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
@@ -21,12 +23,14 @@ object WindowsPluginFrontend extends PluginFrontend {
     val state = createWindowsScript(ss.getLocalPort)
 
     Future {
-      val client = ss.accept()
-      val response =
-        PluginFrontend.runWithInputStream(plugin, client.getInputStream)
-      client.getOutputStream.write(response)
-      client.close()
-      ss.close()
+      blocking {
+        val client = ss.accept()
+        val response =
+          PluginFrontend.runWithInputStream(plugin, client.getInputStream)
+        client.getOutputStream.write(response)
+        client.close()
+        ss.close()
+      }
     }
 
     (state.batFile, state)

--- a/src/test/scala/protocbridge/ProtocIntegrationSpec.scala
+++ b/src/test/scala/protocbridge/ProtocIntegrationSpec.scala
@@ -156,7 +156,7 @@ class ProtocIntegrationSpec extends AnyFlatSpec with Matchers {
 
     Await.result(
       Future.sequence(invocations),
-      Duration(20, SECONDS)
+      Duration(60, SECONDS)
     ) must be(List.fill(parallelProtocInvocations)(0))
   }
 }

--- a/src/test/scala/protocbridge/ProtocIntegrationSpec.scala
+++ b/src/test/scala/protocbridge/ProtocIntegrationSpec.scala
@@ -2,6 +2,7 @@ package protocbridge
 
 import java.io.File
 import java.nio.file.Files
+import java.util.concurrent.Executors
 
 import com.google.protobuf.Descriptors.FileDescriptor
 import com.google.protobuf.compiler.PluginProtos.{
@@ -9,6 +10,8 @@ import com.google.protobuf.compiler.PluginProtos.{
   CodeGeneratorResponse
 }
 
+import scala.concurrent.duration.{Duration, SECONDS}
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.io.Source
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
@@ -16,6 +19,7 @@ import protocbridge.codegen.CodeGenApp
 import protocbridge.codegen.{CodeGenRequest, CodeGenResponse}
 
 object TestJvmPlugin extends ProtocCodeGenerator {
+
   import collection.JavaConverters._
 
   override def run(in: Array[Byte]): Array[Byte] = {
@@ -120,5 +124,39 @@ class ProtocIntegrationSpec extends AnyFlatSpec with Matchers {
       ),
       Seq(protoFile, "-I", protoDir)
     ) must be(1)
+  }
+
+  it should "not deadlock for highly concurrent invocations" in {
+    val availableProcessors = Runtime.getRuntime.availableProcessors
+    assert(availableProcessors > 1, "Several vCPUs needed for the test to be relevant")
+
+    val parallelProtocInvocations = availableProcessors * 8
+    val generatorsByInvocation = availableProcessors * 8
+
+    val protoFile =
+      new File(getClass.getResource("/test.proto").getFile).getAbsolutePath
+    val protoDir = new File(getClass.getResource("/").getFile).getAbsolutePath
+
+    implicit val ec = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(parallelProtocInvocations))
+
+    val invocations = List.fill(parallelProtocInvocations) {
+      Future(
+        ProtocBridge.run(
+          args => com.github.os72.protocjar.Protoc.runProtoc(args.toArray),
+          List.fill(generatorsByInvocation)(
+            Target(
+              JvmGenerator("foo", TestJvmPlugin),
+              Files.createTempDirectory(s"foo").toFile
+            )
+          ),
+          Seq(protoFile, "-I", protoDir)
+        )
+      )
+    }
+
+    Await.result(
+      Future.sequence(invocations),
+      Duration(20, SECONDS)
+    ) must be(List.fill(parallelProtocInvocations)(0))
   }
 }


### PR DESCRIPTION
If the futures spawned by PluginFrontend.prepare() across parallel generators exhaust the global thread pool, with at least one future of each invocation not runnable, both invocations will hang as protoc is waiting for output from one of its plugin that won't run.

This also has the nice effect of increasing throughput in highly parallel environments (with many sbt projects with protos for example).