### PR TITLE
allow passing the same PluginGenerator several times

### DIFF
--- a/bridge/src/test/scala/protocbridge/ProtocBridgeSpec.scala
+++ b/bridge/src/test/scala/protocbridge/ProtocBridgeSpec.scala
@@ -89,18 +89,29 @@ class ProtocBridgeSpec extends AnyFlatSpec with Matchers {
 
     run(
       Seq(
-        Target(gens.plugin("foo", "/path/to/plugin"), TmpPath),
-        Target(gens.plugin("foo", "/otherpath/to/plugin"), TmpPath1),
-        Target(gens.plugin("foo"), TmpPath2),
+        Target(gens.plugin("foo", "/path/to/plugin"), TmpPath, Seq("w")),
+        Target(gens.plugin("foo", "/path/to/plugin"), TmpPath, Seq("x")),
+        Target(gens.plugin("foo", "/otherpath/to/plugin"), TmpPath1, Seq("y")),
+        Target(gens.plugin("foo", "/otherpath/to/plugin"), TmpPath2, Seq("y")),
+        Target(gens.plugin("foo"), TmpPath2, Seq("z")),
         Target(gens.plugin("bar"), TmpPath)
       )
     ) must be(
       Seq(
         "--plugin=protoc-gen-foo_0=/path/to/plugin",
-        "--plugin=protoc-gen-foo_1=/otherpath/to/plugin",
+        "--plugin=protoc-gen-foo_1=/path/to/plugin",
+        "--plugin=protoc-gen-foo_2=/otherpath/to/plugin",
+        "--plugin=protoc-gen-foo_3=/otherpath/to/plugin",
         s"--foo_0_out=$TmpPath",
-        s"--foo_1_out=$TmpPath1",
-        s"--foo_2_out=$TmpPath2",
+        s"--foo_0_opt=w",
+        s"--foo_1_out=$TmpPath",
+        s"--foo_1_opt=x",
+        s"--foo_2_out=$TmpPath1",
+        s"--foo_2_opt=y",
+        s"--foo_3_out=$TmpPath2",
+        s"--foo_3_opt=y",
+        s"--foo_4_out=$TmpPath2",
+        s"--foo_4_opt=z",
         s"--bar_out=$TmpPath"
       )
     )

--- a/bridge/src/test/scala/protocbridge/ProtocBridgeSpec.scala
+++ b/bridge/src/test/scala/protocbridge/ProtocBridgeSpec.scala
@@ -90,36 +90,25 @@ class ProtocBridgeSpec extends AnyFlatSpec with Matchers {
     run(
       Seq(
         Target(gens.plugin("foo", "/path/to/plugin"), TmpPath),
-        Target(gens.plugin("foo", "/path/to/plugin"), TmpPath1),
+        Target(gens.plugin("foo", "/otherpath/to/plugin"), TmpPath1),
         Target(gens.plugin("foo"), TmpPath2),
         Target(gens.plugin("bar"), TmpPath)
       )
     ) must be(
       Seq(
-        "--plugin=protoc-gen-foo=/path/to/plugin",
-        s"--foo_out=$TmpPath",
-        s"--foo_out=$TmpPath1",
-        s"--foo_out=$TmpPath2",
+        "--plugin=protoc-gen-foo_0=/path/to/plugin",
+        "--plugin=protoc-gen-foo_1=/otherpath/to/plugin",
+        s"--foo_0_out=$TmpPath",
+        s"--foo_1_out=$TmpPath1",
+        s"--foo_2_out=$TmpPath2",
         s"--bar_out=$TmpPath"
       )
     )
   }
 
-  it should "not allow ambigious paths for plugins" in {
-    intercept[RuntimeException] {
-      run(
-        Seq(
-          Target(gens.plugin("foo", "/path/to/plugin"), TmpPath1),
-          Target(gens.plugin("foo", "/other/path/to/plugin"), TmpPath1)
-        )
-      )
-    }.getMessage() must be("Different paths found for the plugin: foo")
-  }
-
-  val DefineFlag = "--plugin=protoc-gen-jvm_(.*?)=null".r
-  val UseFlag = s"--jvm_(.*?)_out=${Pattern.quote(TmpPath.toString)}".r
-  val UseFlagParams =
-    s"--jvm_(.*?)_opt=x,y".r
+  val DefineFlag = "--plugin=protoc-gen-(.*?)=null".r
+  val UseFlag = s"--(.*?)_out=${Pattern.quote(TmpPath.toString)}".r
+  val UseFlagParams = s"--(.*?)_opt=x,y".r
 
   it should "allow using FooBarGen" in {
     run(Seq(Target(FoobarGen, TmpPath))) match {
@@ -142,13 +131,13 @@ class ProtocBridgeSpec extends AnyFlatSpec with Matchers {
     ) must be(
       Seq(
         "--plugin=protoc-gen-fff_0=null",
-        "--plugin=protoc-gen-jvm_1=null",
-        "--plugin=protoc-gen-fff_2=null",
+        "--plugin=protoc-gen-fff_1=null",
+        "--plugin=protoc-gen-jvm=null",
         s"--fff_0_out=$TmpPath",
         s"--fff_0_opt=x,y",
-        s"--jvm_1_out=$TmpPath1",
-        s"--fff_2_out=$TmpPath2",
-        s"--fff_2_opt=foo,bar"
+        s"--fff_1_out=$TmpPath2",
+        s"--fff_1_opt=foo,bar",
+        s"--jvm_out=$TmpPath1"
       )
     )
   }


### PR DESCRIPTION
Trying out support for https://github.com/bjaglin/sbt-protoc/commit/53dbd6a87e393209a3e55ee755de83706638b7fd#diff-bbd8a5163e4909c406d2fd2b12cca4345f91859fae3676fd8ee189d121e2c9f1R2-R10 so that https://github.com/scalapb/common-protos/blob/b55b43071974159f9ab05de8457d66e107be86c5/project/BuildHelpers.scala#L61-L65 could package both `flat_package` and regular stubs in the same JAR (unless we want to publish with a `flat` classifier?).

Utltimately, my goal is to make scalapb-validate works out of the box with akka-grpc, as I realized the instructions I added in https://github.com/akka/akka-grpc/commit/19f1be092fb99b56801bbb53c2aa64634dcdc1a9#diff-4780ac674b878a4a2a35e6740dc7efce31de8de2e342719c694de7a36a8e1f83R55-R61 are not enough:
```
object ValidateProto is not a member of package io.envoyproxy.pgv.validate
[error]     io.envoyproxy.pgv.validate.ValidateProto
```