### PR TITLE
Add kotlin to built in generator.

### DIFF
--- a/bridge/src/main/scala/protocbridge/gens.scala
+++ b/bridge/src/main/scala/protocbridge/gens.scala
@@ -23,6 +23,14 @@ object gens {
     PluginGenerator(name, Nil, Some(path))
 
   val javanano = BuiltinGenerator("javanano")
+  val kotlin: BuiltinGenerator = kotlin("3.17.2")
+  def kotlin(runtimeVersion: String): BuiltinGenerator =
+    BuiltinGenerator(
+      "kotlin",
+      suggestedDependencies =
+        Seq(Artifact(JavaProtobufArtifact, "protobuf-kotlin", runtimeVersion))
+    )
+
   val js = BuiltinGenerator("js")
   val objc = BuiltinGenerator("objc")
   val python = BuiltinGenerator("python")


### PR DESCRIPTION
Kotlin support was added in protoc v3.17.0.

This can be used by setting `PB.protocVersion := "3.17.0"` or higher.
