### PR TITLE
windows: write arguments to protoc to a file

### DIFF
--- a/bridge/src/main/scala/protocbridge/ProtocRunner.scala
+++ b/bridge/src/main/scala/protocbridge/ProtocRunner.scala
@@ -1,5 +1,6 @@
 package protocbridge
 
+import java.nio.file.Files
 import scala.io.Source
 import scala.sys.process.Process
 import scala.sys.process.ProcessLogger
@@ -57,6 +58,37 @@ object ProtocRunner {
         None
     }
 
+  def maybeBoxArgsInFile[T](args: Seq[String])(withArgs: Seq[String] => T): T =
+    detectedOs match {
+      case "windows" =>
+        // The default command line length limit is 32767, which we might exceed.
+        // See also https://devblogs.microsoft.com/oldnewthing/20031210-00/?p=41553
+        // As of protobuf v3.5.0, you can pass arguments via a file instead with @<filename>.
+        // Arguments in the file are delimited by a newline and not escaped in any way.
+        val argumentFile = Files.createTempFile("scalapb-arguments-", ".txt")
+
+        try {
+          val writer = Files.newBufferedWriter(argumentFile)
+
+          try {
+            for (arg <- args) {
+              writer.write(arg)
+              writer.write("\n")
+            }
+          } finally {
+            writer.close()
+          }
+
+          val fileArgument = s"@${argumentFile.toString}"
+          withArgs(Seq(fileArgument))
+        } finally {
+          Files.delete(argumentFile)
+        }
+      case _ =>
+        // No special handling: just use the arguments as-is.
+        withArgs(args)
+    }
+
   // This version of maybeNixDynamicLinker() finds ld-linux and also uses it
   // to verify that the executable is dynamic. Newer version (>=3.23.0) of
   // protoc are static, and thus do not load with ld-linux.
@@ -67,11 +99,13 @@ object ProtocRunner {
 
   def apply(executable: String): ProtocRunner[Int] = ProtocRunner.fromFunction {
     case (args, extraEnv) =>
-      Process(
-        command =
-          (maybeNixDynamicLinker(executable).toSeq :+ executable) ++ args,
-        cwd = None,
-        extraEnv: _*
-      ).!
+      maybeBoxArgsInFile(args) { args =>
+        Process(
+          command =
+            (maybeNixDynamicLinker(executable).toSeq :+ executable) ++ args,
+          cwd = None,
+          extraEnv: _*
+        ).!
+      }
   }
 }

--- a/protoc-cache-coursier/src/main/scala/protocbridge/ProtocCacheCoursier.scala
+++ b/protoc-cache-coursier/src/main/scala/protocbridge/ProtocCacheCoursier.scala
@@ -24,9 +24,11 @@ object CoursierProtocCache {
 
     val protoc = getProtoc(version).getAbsolutePath()
 
-    val cmd =
-      (ProtocRunner.maybeNixDynamicLinker(protoc).toSeq :+ protoc) ++ args
-    Process(command = cmd, cwd = None, extraEnv: _*).!
+    ProtocRunner.maybeBoxArgsInFile(args) { args =>
+      val cmd =
+        (ProtocRunner.maybeNixDynamicLinker(protoc).toSeq :+ protoc) ++ args
+      Process(command = cmd, cwd = None, extraEnv: _*).!
+    }
   }
 
   private[this] def download(tmpDir: File, dep: Dependency): Future[File] = {


### PR DESCRIPTION
A colleague on windows noticed an error in our build to this effect:

```
java.io.IOException: Cannot run program "C:\Users\Pieter\AppData\Local\protocbridge\protocbridge\cache\v1\protoc-windows-x86_64-3.19.2.exe": CreateProcess error=206, The filename or extension is too long
```

This occurs on windows when the whole process invocation exceeds 32767 bytes. [Since protobuf v3.5.0](https://github.com/protocolbuffers/protobuf/blob/v3.5.0/src/google/protobuf/compiler/command_line_interface.cc#L1169) you can pass arguments via a file instead, by specifying an argument `@<filename>`, so this PR proposes to just always do that when running protoc on windows.

