### PR TITLE
Switch PluginFrontend to sockets on macOS

### DIFF
--- a/bridge/src/main/scala/protocbridge/frontend/MacPluginFrontend.scala
+++ b/bridge/src/main/scala/protocbridge/frontend/MacPluginFrontend.scala
@@ -1,0 +1,36 @@
+package protocbridge.frontend
+
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.{Files, Path}
+import java.{util => ju}
+
+/** PluginFrontend for macOS.
+  *
+  * Creates a server socket and uses `nc` to communicate with the socket. We use
+  * a server socket instead of named pipes because named pipes are unreliable on
+  * macOS: https://github.com/scalapb/protoc-bridge/issues/366. Since `nc` is
+  * widely available on macOS, this is the simplest and most reliable solution
+  * for macOS.
+  */
+object MacPluginFrontend extends SocketBasedPluginFrontend {
+
+  protected def createShellScript(port: Int): Path = {
+    val shell = sys.env.getOrElse("PROTOCBRIDGE_SHELL", "/bin/sh")
+    // We use 127.0.0.1 instead of localhost for the (very unlikely) case that localhost is missing from /etc/hosts.
+    val scriptName = PluginFrontend.createTempFile(
+      "",
+      s"""|#!$shell
+          |set -e
+          |nc 127.0.0.1 $port
+      """.stripMargin
+    )
+    val perms = new ju.HashSet[PosixFilePermission]
+    perms.add(PosixFilePermission.OWNER_EXECUTE)
+    perms.add(PosixFilePermission.OWNER_READ)
+    Files.setPosixFilePermissions(
+      scriptName,
+      perms
+    )
+    scriptName
+  }
+}

--- a/bridge/src/main/scala/protocbridge/frontend/PluginFrontend.scala
+++ b/bridge/src/main/scala/protocbridge/frontend/PluginFrontend.scala
@@ -5,8 +5,6 @@ import java.nio.file.{Files, Path}
 
 import protocbridge.{ProtocCodeGenerator, ExtraEnv}
 
-import scala.util.Try
-
 /** A PluginFrontend instance provides a platform-dependent way for protoc to
   * communicate with a JVM based ProtocCodeGenerator.
   *
@@ -47,13 +45,7 @@ object PluginFrontend {
       gen: ProtocCodeGenerator,
       request: Array[Byte]
   ): Array[Byte] = {
-    Try {
-      gen.run(request)
-    }.recover { case throwable =>
-      createCodeGeneratorResponseWithError(
-        throwable.toString + "\n" + getStackTrace(throwable)
-      )
-    }.get
+    gen.run(request)
   }
 
   def createCodeGeneratorResponseWithError(error: String): Array[Byte] = {
@@ -116,9 +108,17 @@ object PluginFrontend {
       gen: ProtocCodeGenerator,
       fsin: InputStream,
       env: ExtraEnv
-  ): Array[Byte] = {
+  ): Array[Byte] = try {
     val bytes = readInputStreamToByteArrayWithEnv(fsin, env)
     runWithBytes(gen, bytes)
+  } catch {
+    // This covers all Throwable including OutOfMemoryError, StackOverflowError, etc.
+    // We need to make a best effort to return a response to protoc,
+    // otherwise protoc can hang indefinitely.
+    case throwable: Throwable =>
+      createCodeGeneratorResponseWithError(
+        throwable.toString + "\n" + getStackTrace(throwable)
+      )
   }
 
   def createTempFile(extension: String, content: String): Path = {

--- a/bridge/src/main/scala/protocbridge/frontend/PluginFrontend.scala
+++ b/bridge/src/main/scala/protocbridge/frontend/PluginFrontend.scala
@@ -131,8 +131,13 @@ object PluginFrontend {
 
   def isWindows: Boolean = sys.props("os.name").startsWith("Windows")
 
+  def isMac: Boolean = sys.props("os.name").startsWith("Mac") || sys
+    .props("os.name")
+    .startsWith("Darwin")
+
   def newInstance: PluginFrontend = {
     if (isWindows) WindowsPluginFrontend
+    else if (isMac) MacPluginFrontend
     else PosixPluginFrontend
   }
 }

--- a/bridge/src/main/scala/protocbridge/frontend/PosixPluginFrontend.scala
+++ b/bridge/src/main/scala/protocbridge/frontend/PosixPluginFrontend.scala
@@ -40,6 +40,11 @@ object PosixPluginFrontend extends PluginFrontend {
         val response = PluginFrontend.runWithInputStream(plugin, fsin, env)
         fsin.close()
 
+        // Note that the output pipe must be opened after the input pipe is consumed.
+        // Otherwise, there might be a deadlock that
+        // - The shell script is stuck writing to the input pipe (which has a full buffer),
+        //   and doesn't open the write end of the output pipe.
+        // - This thread is stuck waiting for the write end of the output pipe to be opened.
         val fsout = Files.newOutputStream(outputPipe)
         fsout.write(response)
         fsout.close()

--- a/bridge/src/main/scala/protocbridge/frontend/PosixPluginFrontend.scala
+++ b/bridge/src/main/scala/protocbridge/frontend/PosixPluginFrontend.scala
@@ -12,10 +12,13 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.sys.process._
 import java.{util => ju}
 
-/** PluginFrontend for Unix-like systems (Linux, Mac, etc)
+/** PluginFrontend for Unix-like systems <b>except macOS</b> (Linux, FreeBSD,
+  * etc)
   *
   * Creates a pair of named pipes for input/output and a shell script that
-  * communicates with them.
+  * communicates with them. Compared with `SocketBasedPluginFrontend`, this
+  * frontend doesn't rely on `nc` that might not be available in some
+  * distributions.
   */
 object PosixPluginFrontend extends PluginFrontend {
   case class InternalState(

--- a/bridge/src/main/scala/protocbridge/frontend/SocketBasedPluginFrontend.scala
+++ b/bridge/src/main/scala/protocbridge/frontend/SocketBasedPluginFrontend.scala
@@ -1,0 +1,51 @@
+package protocbridge.frontend
+
+import protocbridge.{ExtraEnv, ProtocCodeGenerator}
+
+import java.net.ServerSocket
+import java.nio.file.{Files, Path}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{Future, blocking}
+
+/** PluginFrontend for Windows and macOS where a server socket is used.
+  */
+abstract class SocketBasedPluginFrontend extends PluginFrontend {
+  case class InternalState(serverSocket: ServerSocket, shellScript: Path)
+
+  override def prepare(
+      plugin: ProtocCodeGenerator,
+      env: ExtraEnv
+  ): (Path, InternalState) = {
+    val ss = new ServerSocket(0) // Bind to any available port.
+    val sh = createShellScript(ss.getLocalPort)
+
+    Future {
+      blocking {
+        // Accept a single client connection from the shell script.
+        val client = ss.accept()
+        try {
+          val response =
+            PluginFrontend.runWithInputStream(
+              plugin,
+              client.getInputStream,
+              env
+            )
+          client.getOutputStream.write(response)
+        } finally {
+          client.close()
+        }
+      }
+    }
+
+    (sh, InternalState(ss, sh))
+  }
+
+  override def cleanup(state: InternalState): Unit = {
+    state.serverSocket.close()
+    if (sys.props.get("protocbridge.debug") != Some("1")) {
+      Files.delete(state.shellScript)
+    }
+  }
+
+  protected def createShellScript(port: Int): Path
+}

--- a/bridge/src/main/scala/protocbridge/frontend/WindowsPluginFrontend.scala
+++ b/bridge/src/main/scala/protocbridge/frontend/WindowsPluginFrontend.scala
@@ -1,53 +1,15 @@
 package protocbridge.frontend
 
-import java.net.ServerSocket
-import java.nio.file.{Files, Path, Paths}
-
-import protocbridge.ExtraEnv
-import protocbridge.ProtocCodeGenerator
-
-import scala.concurrent.blocking
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import java.nio.file.{Path, Paths}
 
 /** A PluginFrontend that binds a server socket to a local interface. The plugin
   * is a batch script that invokes BridgeApp.main() method, in a new JVM with
   * the same parameters as the currently running JVM. The plugin will
   * communicate its stdin and stdout to this socket.
   */
-object WindowsPluginFrontend extends PluginFrontend {
+object WindowsPluginFrontend extends SocketBasedPluginFrontend {
 
-  case class InternalState(batFile: Path)
-
-  override def prepare(
-      plugin: ProtocCodeGenerator,
-      env: ExtraEnv
-  ): (Path, InternalState) = {
-    val ss = new ServerSocket(0)
-    val state = createWindowsScript(ss.getLocalPort)
-
-    Future {
-      blocking {
-        val client = ss.accept()
-        val response =
-          PluginFrontend.runWithInputStream(plugin, client.getInputStream, env)
-        client.getOutputStream.write(response)
-        client.close()
-        ss.close()
-      }
-    }
-
-    (state.batFile, state)
-  }
-
-  override def cleanup(state: InternalState): Unit = {
-    if (sys.props.get("protocbridge.debug") != Some("1")) {
-      Files.delete(state.batFile)
-    }
-  }
-
-  private def createWindowsScript(port: Int): InternalState = {
+  protected def createShellScript(port: Int): Path = {
     val classPath =
       Paths.get(getClass.getProtectionDomain.getCodeSource.getLocation.toURI)
     val classPathBatchString = classPath.toString.replace("%", "%%")
@@ -62,6 +24,6 @@ object WindowsPluginFrontend extends PluginFrontend {
         ].getName} $port
         """.stripMargin
     )
-    InternalState(batchFile)
+    batchFile
   }
 }

--- a/bridge/src/test/scala/protocbridge/frontend/MacPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/MacPluginFrontendSpec.scala
@@ -1,0 +1,15 @@
+package protocbridge.frontend
+
+class MacPluginFrontendSpec extends OsSpecificFrontendSpec {
+  if (PluginFrontend.isMac) {
+    it must "execute a program that forwards input and output to given stream" in {
+      val state = testSuccess(MacPluginFrontend)
+      state.serverSocket.isClosed mustBe true
+    }
+
+    it must "not hang if there is an error in generator" in {
+      val state = testFailure(MacPluginFrontend)
+      state.serverSocket.isClosed mustBe true
+    }
+  }
+}

--- a/bridge/src/test/scala/protocbridge/frontend/OsSpecificFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/OsSpecificFrontendSpec.scala
@@ -1,0 +1,56 @@
+package protocbridge.frontend
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import protocbridge.{ExtraEnv, ProtocCodeGenerator}
+
+import java.io.ByteArrayOutputStream
+import scala.sys.process.ProcessIO
+import scala.util.Random
+
+class OsSpecificFrontendSpec extends AnyFlatSpec with Matchers {
+
+  protected def testPluginFrontend(frontend: PluginFrontend): Array[Byte] = {
+    val random = new Random()
+    val toSend = Array.fill(123)(random.nextInt(256).toByte)
+    val toReceive = Array.fill(456)(random.nextInt(256).toByte)
+    val env = new ExtraEnv(secondaryOutputDir = "tmp")
+
+    val fakeGenerator = new ProtocCodeGenerator {
+      override def run(request: Array[Byte]): Array[Byte] = {
+        request mustBe (toSend ++ env.toByteArrayAsField)
+        toReceive
+      }
+    }
+    val (path, state) = frontend.prepare(
+      fakeGenerator,
+      env
+    )
+    val actualOutput = new ByteArrayOutputStream()
+    val process = sys.process
+      .Process(path.toAbsolutePath.toString)
+      .run(
+        new ProcessIO(
+          writeInput => {
+            writeInput.write(toSend)
+            writeInput.close()
+          },
+          processOutput => {
+            val buffer = new Array[Byte](4096)
+            var bytesRead = 0
+            while (bytesRead != -1) {
+              bytesRead = processOutput.read(buffer)
+              if (bytesRead != -1) {
+                actualOutput.write(buffer, 0, bytesRead)
+              }
+            }
+            processOutput.close()
+          },
+          _.close()
+        )
+      )
+    process.exitValue()
+    frontend.cleanup(state)
+    actualOutput.toByteArray
+  }
+}

--- a/bridge/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
@@ -1,7 +1,7 @@
 package protocbridge.frontend
 
 class PosixPluginFrontendSpec extends OsSpecificFrontendSpec {
-  if (!PluginFrontend.isWindows) {
+  if (!PluginFrontend.isWindows && !PluginFrontend.isMac) {
     it must "execute a program that forwards input and output to given stream" in {
       testSuccess(PosixPluginFrontend)
     }

--- a/bridge/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
@@ -1,0 +1,9 @@
+package protocbridge.frontend
+
+class PosixPluginFrontendSpec extends OsSpecificFrontendSpec {
+  if (!PluginFrontend.isWindows) {
+    it must "execute a program that forwards input and output to given stream" in {
+      testPluginFrontend(PosixPluginFrontend)
+    }
+  }
+}

--- a/bridge/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
@@ -3,7 +3,11 @@ package protocbridge.frontend
 class PosixPluginFrontendSpec extends OsSpecificFrontendSpec {
   if (!PluginFrontend.isWindows) {
     it must "execute a program that forwards input and output to given stream" in {
-      testPluginFrontend(PosixPluginFrontend)
+      testSuccess(PosixPluginFrontend)
+    }
+
+    it must "not hang if there is an OOM in generator" in {
+      testFailure(PosixPluginFrontend)
     }
   }
 }

--- a/bridge/src/test/scala/protocbridge/frontend/WindowsPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/WindowsPluginFrontendSpec.scala
@@ -3,11 +3,13 @@ package protocbridge.frontend
 class WindowsPluginFrontendSpec extends OsSpecificFrontendSpec {
   if (PluginFrontend.isWindows) {
     it must "execute a program that forwards input and output to given stream" in {
-      testSuccess(WindowsPluginFrontend)
+      val state = testSuccess(WindowsPluginFrontend)
+      state.serverSocket.isClosed mustBe true
     }
 
     it must "not hang if there is an OOM in generator" in {
-      testFailure(WindowsPluginFrontend)
+      val state = testFailure(WindowsPluginFrontend)
+      state.serverSocket.isClosed mustBe true
     }
   }
 }

--- a/bridge/src/test/scala/protocbridge/frontend/WindowsPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/WindowsPluginFrontendSpec.scala
@@ -3,7 +3,11 @@ package protocbridge.frontend
 class WindowsPluginFrontendSpec extends OsSpecificFrontendSpec {
   if (PluginFrontend.isWindows) {
     it must "execute a program that forwards input and output to given stream" in {
-      testPluginFrontend(WindowsPluginFrontend)
+      testSuccess(WindowsPluginFrontend)
+    }
+
+    it must "not hang if there is an OOM in generator" in {
+      testFailure(WindowsPluginFrontend)
     }
   }
 }

--- a/bridge/src/test/scala/protocbridge/frontend/WindowsPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/WindowsPluginFrontendSpec.scala
@@ -1,38 +1,9 @@
 package protocbridge.frontend
 
-import java.io.ByteArrayInputStream
-
-import protocbridge.{ProtocCodeGenerator, ExtraEnv}
-
-import scala.sys.process.ProcessLogger
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.must.Matchers
-
-class WindowsPluginFrontendSpec extends AnyFlatSpec with Matchers {
+class WindowsPluginFrontendSpec extends OsSpecificFrontendSpec {
   if (PluginFrontend.isWindows) {
     it must "execute a program that forwards input and output to given stream" in {
-      val toSend = "ping"
-      val toReceive = "pong"
-      val env = new ExtraEnv(secondaryOutputDir = "tmp")
-
-      val fakeGenerator = new ProtocCodeGenerator {
-        override def run(request: Array[Byte]): Array[Byte] = {
-          request mustBe (toSend.getBytes ++ env.toByteArrayAsField)
-          toReceive.getBytes
-        }
-      }
-      val (path, state) = WindowsPluginFrontend.prepare(
-        fakeGenerator,
-        env
-      )
-      val actualOutput = scala.collection.mutable.Buffer.empty[String]
-      val process = sys.process
-        .Process(path.toAbsolutePath.toString)
-        .#<(new ByteArrayInputStream(toSend.getBytes))
-        .run(ProcessLogger(o => actualOutput.append(o)))
-      process.exitValue()
-      actualOutput.mkString mustBe toReceive
-      WindowsPluginFrontend.cleanup(state)
+      testPluginFrontend(WindowsPluginFrontend)
     }
   }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
**This PR is stacked on top of https://github.com/scalapb/protoc-bridge/pull/371. Check the last commit for changes.**

Fixes https://github.com/scalapb/protoc-bridge/issues/366 by switching from named pipes to sockets on macOS.

Linux continues to use named pipes due to `nc` availability concerns. See code comment for details.

Windows version is already using sockets so also did some refactoring.

A side benefit is that sockets are actually much faster on macOS (no difference on Linux):
```
Request 10000 bytes, Response 10000 bytes, Repeat 1000 times
Named pipes on macOS = 33.405s
Sockets on macOS = 15.311s
Named pipes on Linux = 4.223s
Sockets on Linux = 4.219s
```

## How is this tested?
Passes the stress test in https://github.com/scalapb/protoc-bridge/pull/365.
