### PR TITLE
Handle all failures in runWithInputStream

### DIFF
--- a/bridge/src/main/scala/protocbridge/frontend/PosixPluginFrontend.scala
+++ b/bridge/src/main/scala/protocbridge/frontend/PosixPluginFrontend.scala
@@ -40,6 +40,11 @@ object PosixPluginFrontend extends PluginFrontend {
         val response = PluginFrontend.runWithInputStream(plugin, fsin, env)
         fsin.close()
 
+        // Note that the output pipe must be opened after the input pipe is consumed.
+        // Otherwise, there might be a deadlock that
+        // - The shell script is stuck writing to the input pipe (which has a full buffer),
+        //   and doesn't open the write end of the output pipe.
+        // - This thread is stuck waiting for the write end of the output pipe to be opened.
         val fsout = Files.newOutputStream(outputPipe)
         fsout.write(response)
         fsout.close()

--- a/bridge/src/test/scala/protocbridge/frontend/OsSpecificFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/OsSpecificFrontendSpec.scala
@@ -11,27 +11,21 @@ import scala.util.Random
 
 class OsSpecificFrontendSpec extends AnyFlatSpec with Matchers {
 
-  protected def testPluginFrontend(frontend: PluginFrontend): Array[Byte] = {
-    val random = new Random()
-    val toSend = Array.fill(123)(random.nextInt(256).toByte)
-    val toReceive = Array.fill(456)(random.nextInt(256).toByte)
-    val env = new ExtraEnv(secondaryOutputDir = "tmp")
-
-    val fakeGenerator = new ProtocCodeGenerator {
-      override def run(request: Array[Byte]): Array[Byte] = {
-        request mustBe (toSend ++ env.toByteArrayAsField)
-        toReceive
-      }
-    }
+  protected def testPluginFrontend(
+      frontend: PluginFrontend,
+      generator: ProtocCodeGenerator,
+      env: ExtraEnv,
+      request: Array[Byte]
+  ): Array[Byte] = {
     val (path, state) = frontend.prepare(
-      fakeGenerator,
+      generator,
       env
     )
     val actualOutput = new ByteArrayOutputStream()
     val process = sys.process
       .Process(path.toAbsolutePath.toString)
       .run(new ProcessIO(writeInput => {
-        writeInput.write(toSend)
+        writeInput.write(request)
         writeInput.close()
       }, processOutput => {
         val buffer = new Array[Byte](4096)
@@ -47,5 +41,35 @@ class OsSpecificFrontendSpec extends AnyFlatSpec with Matchers {
     process.exitValue()
     frontend.cleanup(state)
     actualOutput.toByteArray
+  }
+
+  protected def testSuccess(frontend: PluginFrontend): Unit = {
+    val random = new Random()
+    val toSend = Array.fill(123)(random.nextInt(256).toByte)
+    val toReceive = Array.fill(456)(random.nextInt(256).toByte)
+    val env = new ExtraEnv(secondaryOutputDir = "tmp")
+
+    val fakeGenerator = new ProtocCodeGenerator {
+      override def run(request: Array[Byte]): Array[Byte] = {
+        request mustBe (toSend ++ env.toByteArrayAsField)
+        toReceive
+      }
+    }
+    val response = testPluginFrontend(frontend, fakeGenerator, env, toSend)
+    response mustBe toReceive
+  }
+
+  protected def testFailure(frontend: PluginFrontend): Unit = {
+    val random = new Random()
+    val toSend = Array.fill(123)(random.nextInt(256).toByte)
+    val env = new ExtraEnv(secondaryOutputDir = "tmp")
+
+    val fakeGenerator = new ProtocCodeGenerator {
+      override def run(request: Array[Byte]): Array[Byte] = {
+        throw new OutOfMemoryError("test error")
+      }
+    }
+    val response = testPluginFrontend(frontend, fakeGenerator, env, toSend)
+    response.length must be > 0
   }
 }

--- a/bridge/src/test/scala/protocbridge/frontend/OsSpecificFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/OsSpecificFrontendSpec.scala
@@ -1,0 +1,51 @@
+package protocbridge.frontend
+
+import org.apache.commons.io.IOUtils
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import protocbridge.{ExtraEnv, ProtocCodeGenerator}
+
+import java.io.ByteArrayOutputStream
+import scala.sys.process.ProcessIO
+import scala.util.Random
+
+class OsSpecificFrontendSpec extends AnyFlatSpec with Matchers {
+
+  protected def testPluginFrontend(frontend: PluginFrontend): Array[Byte] = {
+    val random = new Random()
+    val toSend = Array.fill(123)(random.nextInt(256).toByte)
+    val toReceive = Array.fill(456)(random.nextInt(256).toByte)
+    val env = new ExtraEnv(secondaryOutputDir = "tmp")
+
+    val fakeGenerator = new ProtocCodeGenerator {
+      override def run(request: Array[Byte]): Array[Byte] = {
+        request mustBe (toSend ++ env.toByteArrayAsField)
+        toReceive
+      }
+    }
+    val (path, state) = frontend.prepare(
+      fakeGenerator,
+      env
+    )
+    val actualOutput = new ByteArrayOutputStream()
+    val process = sys.process
+      .Process(path.toAbsolutePath.toString)
+      .run(new ProcessIO(writeInput => {
+        writeInput.write(toSend)
+        writeInput.close()
+      }, processOutput => {
+        val buffer = new Array[Byte](4096)
+        var bytesRead = 0
+        while (bytesRead != -1) {
+          bytesRead = processOutput.read(buffer)
+          if (bytesRead != -1) {
+            actualOutput.write(buffer, 0, bytesRead)
+          }
+        }
+        processOutput.close()
+      }, _.close()))
+    process.exitValue()
+    frontend.cleanup(state)
+    actualOutput.toByteArray
+  }
+}

--- a/bridge/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
@@ -1,0 +1,9 @@
+package protocbridge.frontend
+
+class PosixPluginFrontendSpec extends OsSpecificFrontendSpec {
+  if (!PluginFrontend.isWindows) {
+    it must "execute a program that forwards input and output to given stream" in {
+      testPluginFrontend(PosixPluginFrontend)
+    }
+  }
+}

--- a/bridge/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
@@ -3,7 +3,11 @@ package protocbridge.frontend
 class PosixPluginFrontendSpec extends OsSpecificFrontendSpec {
   if (!PluginFrontend.isWindows) {
     it must "execute a program that forwards input and output to given stream" in {
-      testPluginFrontend(PosixPluginFrontend)
+      testSuccess(PosixPluginFrontend)
+    }
+
+    it must "not hang if there is an OOM in generator" in {
+      testFailure(PosixPluginFrontend)
     }
   }
 }

--- a/bridge/src/test/scala/protocbridge/frontend/WindowsPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/WindowsPluginFrontendSpec.scala
@@ -3,7 +3,11 @@ package protocbridge.frontend
 class WindowsPluginFrontendSpec extends OsSpecificFrontendSpec {
   if (PluginFrontend.isWindows) {
     it must "execute a program that forwards input and output to given stream" in {
-      testPluginFrontend(WindowsPluginFrontend)
+      testSuccess(WindowsPluginFrontend)
+    }
+
+    it must "not hang if there is an OOM in generator" in {
+      testFailure(WindowsPluginFrontend)
     }
   }
 }

--- a/bridge/src/test/scala/protocbridge/frontend/WindowsPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/WindowsPluginFrontendSpec.scala
@@ -1,38 +1,9 @@
 package protocbridge.frontend
 
-import java.io.ByteArrayInputStream
-
-import protocbridge.{ProtocCodeGenerator, ExtraEnv}
-
-import scala.sys.process.ProcessLogger
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.must.Matchers
-
-class WindowsPluginFrontendSpec extends AnyFlatSpec with Matchers {
+class WindowsPluginFrontendSpec extends OsSpecificFrontendSpec {
   if (PluginFrontend.isWindows) {
     it must "execute a program that forwards input and output to given stream" in {
-      val toSend = "ping"
-      val toReceive = "pong"
-      val env = new ExtraEnv(secondaryOutputDir = "tmp")
-
-      val fakeGenerator = new ProtocCodeGenerator {
-        override def run(request: Array[Byte]): Array[Byte] = {
-          request mustBe (toSend.getBytes ++ env.toByteArrayAsField)
-          toReceive.getBytes
-        }
-      }
-      val (path, state) = WindowsPluginFrontend.prepare(
-        fakeGenerator,
-        env
-      )
-      val actualOutput = scala.collection.mutable.Buffer.empty[String]
-      val process = sys.process
-        .Process(path.toAbsolutePath.toString)
-        .#<(new ByteArrayInputStream(toSend.getBytes))
-        .run(ProcessLogger(o => actualOutput.append(o)))
-      process.exitValue()
-      actualOutput.mkString mustBe toReceive
-      WindowsPluginFrontend.cleanup(state)
+      testPluginFrontend(WindowsPluginFrontend)
     }
   }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
**This PR precedes https://github.com/scalapb/protoc-bridge/pull/367.**

During the investigation of https://github.com/scalapb/protoc-bridge/issues/366, while irrelevant to the root cause, two separate issues are found that can cause the program to be stuck.
- If there is an OOM, stack overflow, etc in `gen.run` or `readInputStreamToByteArrayWithEnv`, the `Future` thread will fail but the named pipes & protoc are still waiting for the result, causing the entire program to be stuck. This is now fixed in this PR.
- An attempt to fix the issue with `finally` failed, because the ordering of `fsin.close()` and `Files.newOutputStream(outputPipe)` is crucial. This is now documented in this PR.
