### PR TITLE
[TEST][NO-MERGE] Stress test sockets

### DIFF
--- a/bridge/src/main/scala/protocbridge/frontend/MacPluginFrontend.scala
+++ b/bridge/src/main/scala/protocbridge/frontend/MacPluginFrontend.scala
@@ -1,0 +1,36 @@
+package protocbridge.frontend
+
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.{Files, Path}
+import java.{util => ju}
+
+/** PluginFrontend for macOS.
+  *
+  * Creates a server socket and uses `nc` to communicate with the socket. We use
+  * a server socket instead of named pipes because named pipes are unreliable on
+  * macOS: https://github.com/scalapb/protoc-bridge/issues/366. Since `nc` is
+  * widely available on macOS, this is the simplest and most reliable solution
+  * for macOS.
+  */
+object MacPluginFrontend extends SocketBasedPluginFrontend {
+
+  protected def createShellScript(port: Int): Path = {
+    val shell = sys.env.getOrElse("PROTOCBRIDGE_SHELL", "/bin/sh")
+    // We use 127.0.0.1 instead of localhost for the (very unlikely) case that localhost is missing from /etc/hosts.
+    val scriptName = PluginFrontend.createTempFile(
+      "",
+      s"""|#!$shell
+          |set -e
+          |nc 127.0.0.1 $port
+      """.stripMargin
+    )
+    val perms = new ju.HashSet[PosixFilePermission]
+    perms.add(PosixFilePermission.OWNER_EXECUTE)
+    perms.add(PosixFilePermission.OWNER_READ)
+    Files.setPosixFilePermissions(
+      scriptName,
+      perms
+    )
+    scriptName
+  }
+}

--- a/bridge/src/main/scala/protocbridge/frontend/PluginFrontend.scala
+++ b/bridge/src/main/scala/protocbridge/frontend/PluginFrontend.scala
@@ -5,8 +5,6 @@ import java.nio.file.{Files, Path}
 
 import protocbridge.{ProtocCodeGenerator, ExtraEnv}
 
-import scala.util.Try
-
 /** A PluginFrontend instance provides a platform-dependent way for protoc to
   * communicate with a JVM based ProtocCodeGenerator.
   *
@@ -47,13 +45,7 @@ object PluginFrontend {
       gen: ProtocCodeGenerator,
       request: Array[Byte]
   ): Array[Byte] = {
-    Try {
-      gen.run(request)
-    }.recover { case throwable =>
-      createCodeGeneratorResponseWithError(
-        throwable.toString + "\n" + getStackTrace(throwable)
-      )
-    }.get
+    gen.run(request)
   }
 
   def createCodeGeneratorResponseWithError(error: String): Array[Byte] = {
@@ -116,9 +108,17 @@ object PluginFrontend {
       gen: ProtocCodeGenerator,
       fsin: InputStream,
       env: ExtraEnv
-  ): Array[Byte] = {
+  ): Array[Byte] = try {
     val bytes = readInputStreamToByteArrayWithEnv(fsin, env)
     runWithBytes(gen, bytes)
+  } catch {
+    // This covers all Throwable including OutOfMemoryError, StackOverflowError, etc.
+    // We need to make a best effort to return a response to protoc,
+    // otherwise protoc can hang indefinitely.
+    case throwable: Throwable =>
+      createCodeGeneratorResponseWithError(
+        throwable.toString + "\n" + getStackTrace(throwable)
+      )
   }
 
   def createTempFile(extension: String, content: String): Path = {

--- a/bridge/src/main/scala/protocbridge/frontend/PluginFrontend.scala
+++ b/bridge/src/main/scala/protocbridge/frontend/PluginFrontend.scala
@@ -131,8 +131,13 @@ object PluginFrontend {
 
   def isWindows: Boolean = sys.props("os.name").startsWith("Windows")
 
+  def isMac: Boolean = sys.props("os.name").startsWith("Mac") || sys
+    .props("os.name")
+    .startsWith("Darwin")
+
   def newInstance: PluginFrontend = {
     if (isWindows) WindowsPluginFrontend
+    else if (isMac) MacPluginFrontend
     else PosixPluginFrontend
   }
 }

--- a/bridge/src/main/scala/protocbridge/frontend/PosixPluginFrontend.scala
+++ b/bridge/src/main/scala/protocbridge/frontend/PosixPluginFrontend.scala
@@ -40,6 +40,11 @@ object PosixPluginFrontend extends PluginFrontend {
         val response = PluginFrontend.runWithInputStream(plugin, fsin, env)
         fsin.close()
 
+        // Note that the output pipe must be opened after the input pipe is consumed.
+        // Otherwise, there might be a deadlock that
+        // - The shell script is stuck writing to the input pipe (which has a full buffer),
+        //   and doesn't open the write end of the output pipe.
+        // - This thread is stuck waiting for the write end of the output pipe to be opened.
         val fsout = Files.newOutputStream(outputPipe)
         fsout.write(response)
         fsout.close()

--- a/bridge/src/main/scala/protocbridge/frontend/PosixPluginFrontend.scala
+++ b/bridge/src/main/scala/protocbridge/frontend/PosixPluginFrontend.scala
@@ -12,10 +12,13 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.sys.process._
 import java.{util => ju}
 
-/** PluginFrontend for Unix-like systems (Linux, Mac, etc)
+/** PluginFrontend for Unix-like systems <b>except macOS</b> (Linux, FreeBSD,
+  * etc)
   *
   * Creates a pair of named pipes for input/output and a shell script that
-  * communicates with them.
+  * communicates with them. Compared with `SocketBasedPluginFrontend`, this
+  * frontend doesn't rely on `nc` that might not be available in some
+  * distributions.
   */
 object PosixPluginFrontend extends PluginFrontend {
   case class InternalState(

--- a/bridge/src/main/scala/protocbridge/frontend/SocketBasedPluginFrontend.scala
+++ b/bridge/src/main/scala/protocbridge/frontend/SocketBasedPluginFrontend.scala
@@ -1,0 +1,51 @@
+package protocbridge.frontend
+
+import protocbridge.{ExtraEnv, ProtocCodeGenerator}
+
+import java.net.ServerSocket
+import java.nio.file.{Files, Path}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{Future, blocking}
+
+/** PluginFrontend for Windows and macOS where a server socket is used.
+  */
+abstract class SocketBasedPluginFrontend extends PluginFrontend {
+  case class InternalState(serverSocket: ServerSocket, shellScript: Path)
+
+  override def prepare(
+      plugin: ProtocCodeGenerator,
+      env: ExtraEnv
+  ): (Path, InternalState) = {
+    val ss = new ServerSocket(0) // Bind to any available port.
+    val sh = createShellScript(ss.getLocalPort)
+
+    Future {
+      blocking {
+        // Accept a single client connection from the shell script.
+        val client = ss.accept()
+        try {
+          val response =
+            PluginFrontend.runWithInputStream(
+              plugin,
+              client.getInputStream,
+              env
+            )
+          client.getOutputStream.write(response)
+        } finally {
+          client.close()
+        }
+      }
+    }
+
+    (sh, InternalState(ss, sh))
+  }
+
+  override def cleanup(state: InternalState): Unit = {
+    state.serverSocket.close()
+    if (sys.props.get("protocbridge.debug") != Some("1")) {
+      Files.delete(state.shellScript)
+    }
+  }
+
+  protected def createShellScript(port: Int): Path
+}

--- a/bridge/src/main/scala/protocbridge/frontend/WindowsPluginFrontend.scala
+++ b/bridge/src/main/scala/protocbridge/frontend/WindowsPluginFrontend.scala
@@ -1,53 +1,15 @@
 package protocbridge.frontend
 
-import java.net.ServerSocket
-import java.nio.file.{Files, Path, Paths}
-
-import protocbridge.ExtraEnv
-import protocbridge.ProtocCodeGenerator
-
-import scala.concurrent.blocking
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import java.nio.file.{Path, Paths}
 
 /** A PluginFrontend that binds a server socket to a local interface. The plugin
   * is a batch script that invokes BridgeApp.main() method, in a new JVM with
   * the same parameters as the currently running JVM. The plugin will
   * communicate its stdin and stdout to this socket.
   */
-object WindowsPluginFrontend extends PluginFrontend {
+object WindowsPluginFrontend extends SocketBasedPluginFrontend {
 
-  case class InternalState(batFile: Path)
-
-  override def prepare(
-      plugin: ProtocCodeGenerator,
-      env: ExtraEnv
-  ): (Path, InternalState) = {
-    val ss = new ServerSocket(0)
-    val state = createWindowsScript(ss.getLocalPort)
-
-    Future {
-      blocking {
-        val client = ss.accept()
-        val response =
-          PluginFrontend.runWithInputStream(plugin, client.getInputStream, env)
-        client.getOutputStream.write(response)
-        client.close()
-        ss.close()
-      }
-    }
-
-    (state.batFile, state)
-  }
-
-  override def cleanup(state: InternalState): Unit = {
-    if (sys.props.get("protocbridge.debug") != Some("1")) {
-      Files.delete(state.batFile)
-    }
-  }
-
-  private def createWindowsScript(port: Int): InternalState = {
+  protected def createShellScript(port: Int): Path = {
     val classPath =
       Paths.get(getClass.getProtectionDomain.getCodeSource.getLocation.toURI)
     val classPathBatchString = classPath.toString.replace("%", "%%")
@@ -62,6 +24,6 @@ object WindowsPluginFrontend extends PluginFrontend {
         ].getName} $port
         """.stripMargin
     )
-    InternalState(batchFile)
+    batchFile
   }
 }

--- a/bridge/src/test/scala/protocbridge/frontend/MacPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/MacPluginFrontendSpec.scala
@@ -1,0 +1,15 @@
+package protocbridge.frontend
+
+class MacPluginFrontendSpec extends OsSpecificFrontendSpec {
+  if (PluginFrontend.isMac) {
+    it must "execute a program that forwards input and output to given stream" in {
+      val state = testSuccess(MacPluginFrontend)
+      state.serverSocket.isClosed mustBe true
+    }
+
+    it must "not hang if there is an error in generator" in {
+      val state = testFailure(MacPluginFrontend)
+      state.serverSocket.isClosed mustBe true
+    }
+  }
+}

--- a/bridge/src/test/scala/protocbridge/frontend/OsSpecificFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/OsSpecificFrontendSpec.scala
@@ -1,5 +1,6 @@
 package protocbridge.frontend
 
+import org.apache.commons.io.IOUtils
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 import protocbridge.{ExtraEnv, ProtocCodeGenerator}
@@ -30,17 +31,13 @@ class OsSpecificFrontendSpec extends AnyFlatSpec with Matchers {
             writeInput.close()
           },
           processOutput => {
-            val buffer = new Array[Byte](4096)
-            var bytesRead = 0
-            while (bytesRead != -1) {
-              bytesRead = processOutput.read(buffer)
-              if (bytesRead != -1) {
-                actualOutput.write(buffer, 0, bytesRead)
-              }
-            }
+            IOUtils.copy(processOutput, actualOutput)
             processOutput.close()
           },
-          _.close()
+          processError => {
+            IOUtils.copy(processError, System.err)
+            processError.close()
+          }
         )
       )
     process.exitValue()

--- a/bridge/src/test/scala/protocbridge/frontend/OsSpecificFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/OsSpecificFrontendSpec.scala
@@ -1,0 +1,56 @@
+package protocbridge.frontend
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import protocbridge.{ExtraEnv, ProtocCodeGenerator}
+
+import java.io.ByteArrayOutputStream
+import scala.sys.process.ProcessIO
+import scala.util.Random
+
+class OsSpecificFrontendSpec extends AnyFlatSpec with Matchers {
+
+  protected def testPluginFrontend(frontend: PluginFrontend): Array[Byte] = {
+    val random = new Random()
+    val toSend = Array.fill(123)(random.nextInt(256).toByte)
+    val toReceive = Array.fill(456)(random.nextInt(256).toByte)
+    val env = new ExtraEnv(secondaryOutputDir = "tmp")
+
+    val fakeGenerator = new ProtocCodeGenerator {
+      override def run(request: Array[Byte]): Array[Byte] = {
+        request mustBe (toSend ++ env.toByteArrayAsField)
+        toReceive
+      }
+    }
+    val (path, state) = frontend.prepare(
+      fakeGenerator,
+      env
+    )
+    val actualOutput = new ByteArrayOutputStream()
+    val process = sys.process
+      .Process(path.toAbsolutePath.toString)
+      .run(
+        new ProcessIO(
+          writeInput => {
+            writeInput.write(toSend)
+            writeInput.close()
+          },
+          processOutput => {
+            val buffer = new Array[Byte](4096)
+            var bytesRead = 0
+            while (bytesRead != -1) {
+              bytesRead = processOutput.read(buffer)
+              if (bytesRead != -1) {
+                actualOutput.write(buffer, 0, bytesRead)
+              }
+            }
+            processOutput.close()
+          },
+          _.close()
+        )
+      )
+    process.exitValue()
+    frontend.cleanup(state)
+    actualOutput.toByteArray
+  }
+}

--- a/bridge/src/test/scala/protocbridge/frontend/OsSpecificFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/OsSpecificFrontendSpec.scala
@@ -76,7 +76,7 @@ class OsSpecificFrontendSpec extends AnyFlatSpec with Matchers {
       val (state, response) =
         testPluginFrontend(frontend, fakeGenerator, env, toSend)
       try {
-        response mustBe response
+        response mustBe toReceive
       } catch {
         case e: TestFailedException =>
           System.err.println(s"""Failed on iteration $i of $repeatCount: ${e.getMessage}""")
@@ -85,7 +85,7 @@ class OsSpecificFrontendSpec extends AnyFlatSpec with Matchers {
     val (state, response) =
       testPluginFrontend(frontend, fakeGenerator, env, toSend)
     try {
-      response mustBe response
+      response mustBe toReceive
     } catch {
       case e: TestFailedException =>
         System.err.println(s"""Failed on iteration $repeatCount of $repeatCount: ${e.getMessage}""")

--- a/bridge/src/test/scala/protocbridge/frontend/OsSpecificFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/OsSpecificFrontendSpec.scala
@@ -1,11 +1,15 @@
 package protocbridge.frontend
 
 import org.apache.commons.io.IOUtils
+import org.scalatest.exceptions.TestFailedException
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 import protocbridge.{ExtraEnv, ProtocCodeGenerator}
 
 import java.io.ByteArrayOutputStream
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future, TimeoutException}
 import scala.sys.process.ProcessIO
 import scala.util.Random
 
@@ -40,7 +44,13 @@ class OsSpecificFrontendSpec extends AnyFlatSpec with Matchers {
           }
         )
       )
-    process.exitValue()
+    try {
+      Await.result(Future { process.exitValue() }, 5.seconds)
+    } catch {
+      case _: TimeoutException =>
+        System.err.println(s"Timeout")
+        process.destroy()
+    }
     frontend.cleanup(state)
     (state, actualOutput.toByteArray)
   }
@@ -59,9 +69,27 @@ class OsSpecificFrontendSpec extends AnyFlatSpec with Matchers {
         toReceive
       }
     }
+    // Repeat 100,000 times since named pipes on macOS are flaky.
+    val repeatCount = 100000
+    for (i <- 1 until repeatCount) {
+      if (i % 100 == 1) println(s"Running iteration $i of $repeatCount")
+      val (state, response) =
+        testPluginFrontend(frontend, fakeGenerator, env, toSend)
+      try {
+        response mustBe response
+      } catch {
+        case e: TestFailedException =>
+          System.err.println(s"""Failed on iteration $i of $repeatCount: ${e.getMessage}""")
+      }
+    }
     val (state, response) =
       testPluginFrontend(frontend, fakeGenerator, env, toSend)
-    response mustBe toReceive
+    try {
+      response mustBe response
+    } catch {
+      case e: TestFailedException =>
+        System.err.println(s"""Failed on iteration $repeatCount of $repeatCount: ${e.getMessage}""")
+    }
     state
   }
 

--- a/bridge/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
@@ -3,11 +3,11 @@ package protocbridge.frontend
 class PosixPluginFrontendSpec extends OsSpecificFrontendSpec {
   if (!PluginFrontend.isWindows && !PluginFrontend.isMac) {
     it must "execute a program that forwards input and output to given stream" in {
-      testSuccess(PosixPluginFrontend)
+      testSuccess(MacPluginFrontend)
     }
 
     it must "not hang if there is an OOM in generator" in {
-      testFailure(PosixPluginFrontend)
+      testFailure(MacPluginFrontend)
     }
   }
 }

--- a/bridge/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
@@ -1,7 +1,7 @@
 package protocbridge.frontend
 
 class PosixPluginFrontendSpec extends OsSpecificFrontendSpec {
-  if (!PluginFrontend.isWindows) {
+  if (!PluginFrontend.isWindows && !PluginFrontend.isMac) {
     it must "execute a program that forwards input and output to given stream" in {
       testSuccess(PosixPluginFrontend)
     }

--- a/bridge/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
@@ -1,0 +1,9 @@
+package protocbridge.frontend
+
+class PosixPluginFrontendSpec extends OsSpecificFrontendSpec {
+  if (!PluginFrontend.isWindows) {
+    it must "execute a program that forwards input and output to given stream" in {
+      testPluginFrontend(PosixPluginFrontend)
+    }
+  }
+}

--- a/bridge/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
@@ -3,7 +3,11 @@ package protocbridge.frontend
 class PosixPluginFrontendSpec extends OsSpecificFrontendSpec {
   if (!PluginFrontend.isWindows) {
     it must "execute a program that forwards input and output to given stream" in {
-      testPluginFrontend(PosixPluginFrontend)
+      testSuccess(PosixPluginFrontend)
+    }
+
+    it must "not hang if there is an OOM in generator" in {
+      testFailure(PosixPluginFrontend)
     }
   }
 }

--- a/bridge/src/test/scala/protocbridge/frontend/SocketAllocationSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/SocketAllocationSpec.scala
@@ -1,0 +1,50 @@
+package protocbridge.frontend
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+
+import java.lang.management.ManagementFactory
+import java.net.ServerSocket
+import scala.collection.mutable
+import scala.sys.process._
+import scala.util.{Failure, Success, Try}
+
+class SocketAllocationSpec extends AnyFlatSpec with Matchers {
+  it must "allocate an unused port" in {
+    val repeatCount = 100000
+
+    val currentPid = getCurrentPid
+    val portConflictCount = mutable.Map[Int, Int]()
+
+    for (i <- 1 to repeatCount) {
+      if (i % 100 == 1) println(s"Running iteration $i of $repeatCount")
+
+      val serverSocket = new ServerSocket(0) // Bind to any available port.
+      try {
+        val port = serverSocket.getLocalPort
+        Try {
+          s"lsof -i :$port -t".!!.trim
+        } match {
+          case Success(output) =>
+            if (output.nonEmpty) {
+              val pids = output.split("\n").filterNot(_ == currentPid.toString)
+              if (pids.nonEmpty) {
+                System.err.println("Port conflict detected on port " + port + " with PIDs: " + pids.mkString(", "))
+                portConflictCount(port) = portConflictCount.getOrElse(port, 0) + 1
+              }
+            }
+          case Failure(_) => // Ignore failure and continue
+        }
+      } finally {
+        serverSocket.close()
+      }
+    }
+
+    assert(portConflictCount.isEmpty, s"Found the following ports in use out of $repeatCount: $portConflictCount")
+  }
+
+  private def getCurrentPid: Int = {
+    val jvmName = ManagementFactory.getRuntimeMXBean.getName
+    val pid = jvmName.split("@")(0)
+    pid.toInt
+  }
+}

--- a/bridge/src/test/scala/protocbridge/frontend/WindowsPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/WindowsPluginFrontendSpec.scala
@@ -3,11 +3,13 @@ package protocbridge.frontend
 class WindowsPluginFrontendSpec extends OsSpecificFrontendSpec {
   if (PluginFrontend.isWindows) {
     it must "execute a program that forwards input and output to given stream" in {
-      testSuccess(WindowsPluginFrontend)
+      val state = testSuccess(WindowsPluginFrontend)
+      state.serverSocket.isClosed mustBe true
     }
 
     it must "not hang if there is an OOM in generator" in {
-      testFailure(WindowsPluginFrontend)
+      val state = testFailure(WindowsPluginFrontend)
+      state.serverSocket.isClosed mustBe true
     }
   }
 }

--- a/bridge/src/test/scala/protocbridge/frontend/WindowsPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/WindowsPluginFrontendSpec.scala
@@ -3,7 +3,11 @@ package protocbridge.frontend
 class WindowsPluginFrontendSpec extends OsSpecificFrontendSpec {
   if (PluginFrontend.isWindows) {
     it must "execute a program that forwards input and output to given stream" in {
-      testPluginFrontend(WindowsPluginFrontend)
+      testSuccess(WindowsPluginFrontend)
+    }
+
+    it must "not hang if there is an OOM in generator" in {
+      testFailure(WindowsPluginFrontend)
     }
   }
 }

--- a/bridge/src/test/scala/protocbridge/frontend/WindowsPluginFrontendSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/WindowsPluginFrontendSpec.scala
@@ -1,38 +1,9 @@
 package protocbridge.frontend
 
-import java.io.ByteArrayInputStream
-
-import protocbridge.{ProtocCodeGenerator, ExtraEnv}
-
-import scala.sys.process.ProcessLogger
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.must.Matchers
-
-class WindowsPluginFrontendSpec extends AnyFlatSpec with Matchers {
+class WindowsPluginFrontendSpec extends OsSpecificFrontendSpec {
   if (PluginFrontend.isWindows) {
     it must "execute a program that forwards input and output to given stream" in {
-      val toSend = "ping"
-      val toReceive = "pong"
-      val env = new ExtraEnv(secondaryOutputDir = "tmp")
-
-      val fakeGenerator = new ProtocCodeGenerator {
-        override def run(request: Array[Byte]): Array[Byte] = {
-          request mustBe (toSend.getBytes ++ env.toByteArrayAsField)
-          toReceive.getBytes
-        }
-      }
-      val (path, state) = WindowsPluginFrontend.prepare(
-        fakeGenerator,
-        env
-      )
-      val actualOutput = scala.collection.mutable.Buffer.empty[String]
-      val process = sys.process
-        .Process(path.toAbsolutePath.toString)
-        .#<(new ByteArrayInputStream(toSend.getBytes))
-        .run(ProcessLogger(o => actualOutput.append(o)))
-      process.exitValue()
-      actualOutput.mkString mustBe toReceive
-      WindowsPluginFrontend.cleanup(state)
+      testPluginFrontend(WindowsPluginFrontend)
     }
   }
 }

--- a/port_conflict.py
+++ b/port_conflict.py
@@ -1,0 +1,68 @@
+import os
+import socket
+import subprocess
+import sys
+
+def is_port_in_use(port, current_pid):
+    """
+    Check if the given port is in use by other processes, excluding the current process.
+    
+    :param port: Port number to check
+    :param pid: Current process ID to exclude from the result
+    :return: True if the port is in use by another process, False otherwise
+    """
+    try:
+        # Run lsof command to check if any process is using the port
+        result = subprocess.run(
+            ['lsof', '-i', f':{port}', '-t'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+        output = result.stdout.strip()
+
+        if output:
+            # Check if the output contains lines with processes other than the current one
+            return [
+                line
+                for line in output.split('\n')
+                if line != str(current_pid)
+            ]
+        return []
+    except subprocess.CalledProcessError as e:
+        print(f"Error checking port: {e}", file=sys.stderr)
+        return []
+
+def main():
+    repeat_count = 10000
+
+    current_pid = os.getpid()  # Get the current process ID
+    port_conflict_count = {}
+
+    for i in range(1, repeat_count + 1):
+        if i % 100 == 1:
+            print(f"Running iteration {i} of {repeat_count}")
+
+        # Bind to an available port (port 0)
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(('', 0))  # Bind to port 0 to get an available port
+        port = sock.getsockname()[1]  # Get the actual port number assigned
+
+        # Check if the port is in use by any other process
+        pids = is_port_in_use(port, current_pid)
+        if pids:
+            print(f"Port conflict detected on port {port} with PIDs: {', '.join(pids)}", file=sys.stderr)
+            port_conflict_count[port] = port_conflict_count.get(port, 0) + 1
+
+        # Close the socket after checking
+        sock.close()
+
+    if port_conflict_count:
+        print("Ports that were found to be in use and their collision counts:")
+        for port, count in port_conflict_count.items():
+            print(f"Port {port} was found in use {count} times")
+    else:
+        print("No ports were found to be in use.")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
It's found that the `nc` based communication introduced in https://github.com/scalapb/protoc-bridge/pull/367, while more reliable than the named-pipe based communication, can still get stuck or have mismatched messages occasionally during 100k runs.

One 100k run had 8 timeouts, 20 empty responses, and 4 Bad Request response as shown below. This is better than with named pipes (70 timeouts out of 100k times) but still pretty unreliable.

```
git clone git@github.com:bell-db/protoc-bridge.git
cd protoc-bridge
git fetch origin bell-db/v0.9.7-socket-stress-test:bell-db/v0.9.7-socket-stress-test
git checkout bell-db/v0.9.7-socket-stress-test
sbt "testOnly protocbridge.frontend.MacPluginFrontendSpec"
```

Moreover, sometimes the returned message is pretty confusing:
```
SSH-2.0-OpenSSH_9.3p1 Ubuntu-1ubuntu3.2
```

```
HTTP/1.1 400 Bad Request
Content-Type: text/plain; charset=utf-8
Connection: close

400 Bad Request
```

The same test (with `nc -N`) can pass on Linux (Ubuntu 20.04.6 LTS, Xeon(R) Platinum 8375C).

## Port conflict
It turns out that on macOS (14.6.1, M2 Max), [new ServerSocket(0)](https://github.com/scalapb/protoc-bridge/blob/21cedec433153f3b8d5d7f8b09a23e9a316c90fb/bridge/src/main/scala/protocbridge/frontend/SocketBasedPluginFrontend.scala#L19) (or Python `sock.bind(('', 0))`) might return a port already in use by another process (even those already for a while, so not a race condition in allocation). This can be confirmed with
```
sbt "testOnly protocbridge.frontend.SocketAllocationSpec"
python3 port_conflict.py
```

Such commands can succeed with no conflict found on Linux (Ubuntu 20.04.6 LTS, Xeon(R) Platinum 8375C).

## Pop-up
There are reports that `nc` (invoked from Bazel) can trigger a pop-up on macOS "Do you want the application "nc" to accept incoming network connections?" or fail with `nc: connectx to 127.0.0.1 port 59416 (tcp) failed: Operation not permitted`. It's not clear how to reliably reproduce this issue.
