### PR TITLE
Retry getting a free port on macos

### DIFF
--- a/bridge/src/main/scala/protocbridge/frontend/SocketBasedPluginFrontend.scala
+++ b/bridge/src/main/scala/protocbridge/frontend/SocketBasedPluginFrontend.scala
@@ -1,22 +1,28 @@
 package protocbridge.frontend
 
+import protocbridge.frontend.SocketBasedPluginFrontend.getFreeSocket
 import protocbridge.{ExtraEnv, ProtocCodeGenerator}
 
+import java.lang.management.ManagementFactory
 import java.net.ServerSocket
 import java.nio.file.{Files, Path}
+import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Future, blocking}
+import scala.util.{Failure, Success, Try}
+
 
 /** PluginFrontend for Windows and macOS where a server socket is used.
-  */
+ */
 abstract class SocketBasedPluginFrontend extends PluginFrontend {
+
   case class InternalState(serverSocket: ServerSocket, shellScript: Path)
 
   override def prepare(
-      plugin: ProtocCodeGenerator,
-      env: ExtraEnv
-  ): (Path, InternalState) = {
-    val ss = new ServerSocket(0) // Bind to any available port.
+                        plugin: ProtocCodeGenerator,
+                        env: ExtraEnv
+                      ): (Path, InternalState) = {
+    val ss = getFreeSocket()
     val sh = createShellScript(ss.getLocalPort)
 
     Future {
@@ -48,4 +54,58 @@ abstract class SocketBasedPluginFrontend extends PluginFrontend {
   }
 
   protected def createShellScript(port: Int): Path
+}
+
+
+object SocketBasedPluginFrontend {
+
+  private lazy val currentPid: Int = {
+    val jvmName = ManagementFactory.getRuntimeMXBean.getName
+    val pid = jvmName.split("@")(0)
+    pid.toInt
+  }
+
+  private def isSocketConflict(currentPid: Int, port: Int): Boolean = {
+    import scala.sys.process._
+    Try {
+      s"/usr/sbin/lsof -i :$port -t".!!.trim
+    } match {
+      case Success(output) =>
+        if (output.nonEmpty) {
+          val otherPids = output.split("\n").filterNot(_ == currentPid.toString)
+          otherPids.nonEmpty
+        } else {
+          true
+        }
+      case Failure(e) =>
+        System.err.println(s"Failure checking if port is busy: $e")
+        false
+    }
+  }
+
+  @tailrec
+  private def getFreeSocketForMac(currentPid: Int, attemptsLeft: Int): ServerSocket = {
+    val sock = new ServerSocket(0)
+    if (isSocketConflict(currentPid, sock.getLocalPort)) {
+      if (attemptsLeft > 0) {
+        System.out.println(s"Socket conflict on port ${sock.getLocalPort}, retry, $attemptsLeft attempts left")
+        getFreeSocketForMac(currentPid, attemptsLeft - 1)
+      } else {
+        System.out.println(s"Socket conflict on port ${sock.getLocalPort}, no retries left, you're gonna get an error")
+        sock
+      }
+    } else {
+      sock
+    }
+  }
+
+  def getFreeSocket(maxAttempts: Int = 5): ServerSocket = {
+    if (!PluginFrontend.isMac) {
+      // Bind to any available port.
+      new ServerSocket(0)
+    } else {
+      //new ServerSocket(0) on mac might return a socket already in use, so here's a hack
+      getFreeSocketForMac(currentPid, maxAttempts)
+    }
+  }
 }

--- a/bridge/src/test/scala/protocbridge/frontend/SocketAllocationSpec.scala
+++ b/bridge/src/test/scala/protocbridge/frontend/SocketAllocationSpec.scala
@@ -1,0 +1,49 @@
+package protocbridge.frontend
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+
+import java.lang.management.ManagementFactory
+import scala.collection.mutable
+import scala.sys.process._
+import scala.util.{Failure, Success, Try}
+
+class SocketAllocationSpec extends AnyFlatSpec with Matchers {
+  it must "allocate an unused port" in {
+    val repeatCount = 100000
+
+    val currentPid = getCurrentPid
+    val portConflictCount = mutable.Map[Int, Int]()
+
+    for (i <- 1 to repeatCount) {
+      if (i % 100 == 1) println(s"Running iteration $i of $repeatCount")
+
+      val serverSocket = SocketBasedPluginFrontend.getFreeSocket()
+      try {
+        val port = serverSocket.getLocalPort
+        Try {
+          s"lsof -i :$port -t".!!.trim
+        } match {
+          case Success(output) =>
+            if (output.nonEmpty) {
+              val pids = output.split("\n").filterNot(_ == currentPid.toString)
+              if (pids.nonEmpty) {
+                System.err.println("Port conflict detected on port " + port + " with PIDs: " + pids.mkString(", "))
+                portConflictCount(port) = portConflictCount.getOrElse(port, 0) + 1
+              }
+            }
+          case Failure(_) => // Ignore failure and continue
+        }
+      } finally {
+        serverSocket.close()
+      }
+    }
+
+    assert(portConflictCount.isEmpty, s"Found the following ports in use out of $repeatCount: $portConflictCount")
+  }
+
+  private def getCurrentPid: Int = {
+    val jvmName = ManagementFactory.getRuntimeMXBean.getName
+    val pid = jvmName.split("@")(0)
+    pid.toInt
+  }
+}


### PR DESCRIPTION
Hi, we're having troubles with sometimes unreliable macOS sockets in our bazel monorepo, protoc-bridge version 0.9.8. We have about 3k scala proto targets, and every once in a week a socket problem causes a build to stuck with:

```
INFO: From ProtoScalaPBRule some_path/my_file_proto_scala_scalapb.srcjar:
Socket conflict on port 50356, you're gonna get an error <-- this line is added by me with a patched version of protoc-bridge
ERROR: /Users/reimai/some_path/BUILD:116:14: scala //some_path:my_file_proto failed: (Exit 1): scalac failed: error executing Scalac command (from target //some_path:my_file_proto) bazel-out/darwin_arm64-opt-exec-ST-a828a81199fe/bin/external/io_bazel_rules_scala/src/java/io/bazel/rulesscala/scalac/scalac '--jvm_flag=-Xss8m' '--jvm_flag=-Djava.security.manager=allow' ... (remaining 1 argument skipped)
Must have input files from either source jars or local files.
java.lang.RuntimeException: Must have input files from either source jars or local files.
	at io.bazel.rulesscala.scalac.ScalacWorker.work(ScalacWorker.java:66)
	at io.bazel.rulesscala.worker.Worker.persistentWorkerMain(Worker.java:86)
	at io.bazel.rulesscala.worker.Worker.workerMain(Worker.java:39)
	at io.bazel.rulesscala.scalac.ScalacWorker.main(ScalacWorker.java:33)
INFO: Elapsed time: 503.350s, Critical Path: 67.27s
INFO: 46560 processes: 26563 internal, 12419 darwin-sandbox, 7578 worker.
ERROR: Build did NOT complete successfully
```

It's non-retryable, though deleting an empty bazel-out/darwin_arm64-fastbuild/bin/some_path/my_file_proto_scala_scalapb.srcjar and rebuilding w/o remote cache helps.

This bug is also causing other problems, such as:

```
--scala_out: protoc-gen-scala: Plugin output is unparseable: \000\000\030\004\000\000\000\000\000\000\004\000@\000\000\000\005\000@\000\000\000\006\000\000@\000\376\003\000\000\000\001\000\000\004\010\000\000\000\000\000\000?\000\001
```

and

```
my_file.proto: is a proto3 file that contains optional fields, but code generator protoc-gen-scala hasn't been updated to support optional fields in proto3. Please ask the owner of this code generator to support proto3 optional.
```

but these could be fixed by a retry.

I've added a hack to get a free socket with more reliability by simply retrying new ServerSocket(0). Socket availability check is copied from [socket stress test](https://github.com/scalapb/protoc-bridge/pull/381/files#diff-5a4cb7e18cd4817381619f50065fc077cb049ad145f46c9256525b02c49cab0d). This hack passes 100k iterations of stress test (actually even 3 retries would be sufficient) and helps our team with proto-on-mac problems.

Would you accept it as a temporary solution? These was not much action around [mac problem](https://github.com/scalapb/protoc-bridge/issues/379) for a half of a year and the problem is still visible to end users, although it's not as frequent as it was with named pipes.


