### PR TITLE
Fix getting a free socket on macos

### DIFF
--- a/bridge/src/main/scala/protocbridge/frontend/SocketBasedPluginFrontend.scala
+++ b/bridge/src/main/scala/protocbridge/frontend/SocketBasedPluginFrontend.scala
@@ -1,6 +1,5 @@
 package protocbridge.frontend
 
-import protocbridge.frontend.SocketBasedPluginFrontend.getFreeSocket
 import protocbridge.{ExtraEnv, ProtocCodeGenerator}
 
 import java.net.{InetAddress, ServerSocket}
@@ -8,18 +7,22 @@ import java.nio.file.{Files, Path}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Future, blocking}
 
-
 /** PluginFrontend for Windows and macOS where a server socket is used.
- */
+  */
 abstract class SocketBasedPluginFrontend extends PluginFrontend {
 
   case class InternalState(serverSocket: ServerSocket, shellScript: Path)
 
   override def prepare(
-                        plugin: ProtocCodeGenerator,
-                        env: ExtraEnv
-                      ): (Path, InternalState) = {
-    val ss = getFreeSocket()
+      plugin: ProtocCodeGenerator,
+      env: ExtraEnv
+  ): (Path, InternalState) = {
+
+    /** we need to specify an address, otherwise it uses ANY (*.* in netstat)
+      * which does not conflict with existing 'localhost' sockets on macos,
+      * resulting in a conflict later on in MacPluginFrontend
+      */
+    val ss = new ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))
     val sh = createShellScript(ss.getLocalPort)
 
     Future {
@@ -51,22 +54,4 @@ abstract class SocketBasedPluginFrontend extends PluginFrontend {
   }
 
   protected def createShellScript(port: Int): Path
-}
-
-
-object SocketBasedPluginFrontend {
-
-  /**
-   * for mac we need to specify an address, otherwise it uses ANY (*.* in netstat)
-   * which does not conflict with existing 'localhost' sockets,
-   * resulting in a conflict later on in MacPluginFrontend
-   */
-  def getFreeSocket(): ServerSocket = {
-    if (!PluginFrontend.isMac) {
-      // Bind to any available port.
-      new ServerSocket(0)
-    } else {
-      new ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))
-    }
-  }
 }

--- a/bridge/src/main/scala/protocbridge/frontend/SocketBasedPluginFrontend.scala
+++ b/bridge/src/main/scala/protocbridge/frontend/SocketBasedPluginFrontend.scala
@@ -1,22 +1,25 @@
 package protocbridge.frontend
 
+import protocbridge.frontend.SocketBasedPluginFrontend.getFreeSocket
 import protocbridge.{ExtraEnv, ProtocCodeGenerator}
 
-import java.net.ServerSocket
+import java.net.{InetAddress, ServerSocket}
 import java.nio.file.{Files, Path}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Future, blocking}
 
+
 /** PluginFrontend for Windows and macOS where a server socket is used.
-  */
+ */
 abstract class SocketBasedPluginFrontend extends PluginFrontend {
+
   case class InternalState(serverSocket: ServerSocket, shellScript: Path)
 
   override def prepare(
-      plugin: ProtocCodeGenerator,
-      env: ExtraEnv
-  ): (Path, InternalState) = {
-    val ss = new ServerSocket(0) // Bind to any available port.
+                        plugin: ProtocCodeGenerator,
+                        env: ExtraEnv
+                      ): (Path, InternalState) = {
+    val ss = getFreeSocket()
     val sh = createShellScript(ss.getLocalPort)
 
     Future {
@@ -48,4 +51,22 @@ abstract class SocketBasedPluginFrontend extends PluginFrontend {
   }
 
   protected def createShellScript(port: Int): Path
+}
+
+
+object SocketBasedPluginFrontend {
+
+  /**
+   * for mac we need to specify an address, otherwise it uses ANY (*.* in netstat)
+   * which does not conflict with existing 'localhost' sockets,
+   * resulting in a conflict later on in MacPluginFrontend
+   */
+  def getFreeSocket(): ServerSocket = {
+    if (!PluginFrontend.isMac) {
+      // Bind to any available port.
+      new ServerSocket(0)
+    } else {
+      new ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))
+    }
+  }
 }


### PR DESCRIPTION
Here is a new fix for a [free socket on mac problem](https://github.com/scalapb/protoc-bridge/pull/418), without restry.
Turns out mac allows a socket on ANY host (*.* in netstat) to bind even though a socket with localhost and a same port is present in LISTENING state. This is different from linux, where such an attempt would fail with a java.net.BindException.

A way to fix this is by simply passing a localhost (or rather 127.0.0.1, to match MacPluginFrontend) to ServerSocket constructor.
I've test it on my project, and got no failures on 5 rebuilds (it used to be 2 failed bazel targets per rebuild on protoc-bridge:0.9.8).
