### PR TITLE
Remove p.complete(null) from FileCache

### DIFF
--- a/bridge/src/main/scala/protocbridge/FileCache.scala
+++ b/bridge/src/main/scala/protocbridge/FileCache.scala
@@ -38,8 +38,8 @@ final class FileCache[K](
         }
         p.future
       } else {
-        // discard the promise
-        p.complete(null)
+        // Another download for this key is already in progress; return its future.
+        // The newly-created promise p is abandoned and will be GC'd.
         prev.future
       }
     }

--- a/build.sbt
+++ b/build.sbt
@@ -39,22 +39,6 @@ lazy val bridge: Project = project
         conflictWarning.value
       }
     },
-    Test / testOptions ++= {
-      scalaBinaryVersion.value match {
-        case "2.12" =>
-          Nil
-        case _ =>
-          // TODO
-          Seq(
-            Tests.Exclude(
-              Set(
-                "protocbridge.codegen.CodeGenAppSpec",
-                "protocbridge.ProtocCacheSpec"
-              )
-            )
-          )
-      }
-    },
     scalacOptions ++= (if (scalaVersion.value.startsWith("2.13."))
                          Seq("-Wconf:origin=.*JavaConverters.*:s")
                        else Nil),


### PR DESCRIPTION
Since Scala 2.13+, `Promise.complete` has a `Object.requireNonNull`, causing `p.complete(null)` to throw a `NullPointerException`. The discarded promise doesn't need to be completed, it will be abandoned and GC'd. This caused issues in sbt-protoc on sbt 2.x.
